### PR TITLE
Fix https://github.com/jubos/fake-s3/issues/114

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -460,7 +460,7 @@ module FakeS3
       s_req.path = webrick_req.path
       s_req.is_path_style = true
 
-      if !@root_hostnames.include?(host)
+      if !@root_hostnames.include?(host) && host =~ /^(.+).s3.amazonaws.com$/
         s_req.bucket = host.split(".")[0]
         s_req.is_path_style = false
       end


### PR DESCRIPTION
Our fork of `fake_s3` can't recognize a request host and compose a 404 response (because we have a different network in docker).

see https://github.com/jubos/fake-s3/issues/114 thread for more details
